### PR TITLE
feat: add --totp CLI parameter for 2FA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.0] - 2026-02-23
 
+### Added
+
+- `-totp`/`--totp` CLI parameter to pass a TOTP secret for 2FA (optional, only used with `-em` and `-pw`).
+
 ### Changed
 
 - **Migrated to [uv](https://docs.astral.sh/uv/)** as the package manager, replacing pip/venv.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ accounts: # The accounts to use. You can put zero, one or an infinite number of 
 
 ```
 usage: main.py [-h] [-c CONFIG] [-C] [-v] [-l LANG] [-g GEO] [-em EMAIL] [-pw PASSWORD]
-               [-p PROXY] [-t {desktop,mobile,both}] [-da] [-d] [-r]
+               [-totp TOTP] [-p PROXY] [-t {desktop,mobile,both}] [-da] [-d] [-r]
 
 A simple bot that uses Selenium to farm M$ Rewards in Python
 
@@ -173,6 +173,8 @@ options:
                         Email address of the account to run. Only used if a password is given.
   -pw PASSWORD, --password PASSWORD
                         Password of the account to run. Only used if an email is given.
+  -totp TOTP, --totp TOTP
+                        TOTP secret for 2FA. Only used if email and password are given.
   -p PROXY, --proxy PROXY
                         Global Proxy, supports http/https/socks4/socks5 (overrides config per-
                         account proxies) `(ex: http://user:pass@host:port)`

--- a/src/utils.py
+++ b/src/utils.py
@@ -446,6 +446,13 @@ def argumentParser() -> Namespace:
         help="Password of the account to run. Only used if an email is given.",
     )
     parser.add_argument(
+        "-totp",
+        "--totp",
+        type=str,
+        default=None,
+        help="TOTP secret for 2FA. Only used if email and password are given.",
+    )
+    parser.add_argument(
         "-p",
         "--proxy",
         type=str,
@@ -514,12 +521,13 @@ def commandLineArgumentsAsConfig(args: Namespace) -> Config:
         config.search = Config()
         config.search.type = args.searchtype
     if args.email and args.password:
-        config.accounts = [
-            Config(
-                email=args.email,
-                password=args.password,
-            )
-        ]
+        account = Config(
+            email=args.email,
+            password=args.password,
+        )
+        if args.totp:
+            account.totp = args.totp
+        config.accounts = [account]
 
     return config
 


### PR DESCRIPTION
- Add -totp/--totp argument to pass TOTP secret via command line
- Optional, only used when email and password are also provided
- Update usage help text in README.md
- Update CHANGELOG.md