### PR TITLE
feat: add virtual authenticator to bypass passkey dialogs (v3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-02-25
+
+### Added
+
+- Virtual CTAP2 authenticator to bypass native WebAuthn/passkey dialogs. Prevents OS-level
+  prompts like "Create a passkey" from interrupting the bot.
+
 ## [3.1.0] - 2026-02-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ms-rewards-farmer"
-version = "3.1.0"
+version = "3.2.0"
 description = "A 'simple' python application that uses Selenium to help with your M$ Rewards"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/browser.py
+++ b/src/browser.py
@@ -9,6 +9,7 @@ import seleniumwire.undetected_chromedriver as webdriver
 import undetected_chromedriver
 from selenium.webdriver import ChromeOptions
 from selenium.webdriver.chrome.webdriver import WebDriver
+from selenium.webdriver.common.virtual_authenticator import VirtualAuthenticatorOptions, Protocol, Transport
 
 from src import RemainingSearches
 from src.userAgentGenerator import GenerateUserAgent
@@ -166,6 +167,17 @@ class Browser:
                     "enabled": True,
                 },
             )
+
+        # Register a virtual CTAP2 authenticator so that the browser silently
+        # satisfies WebAuthn/passkey requests instead of showing native OS
+        # dialogs (e.g. "Create a passkey" or "Use your security key").
+        virtual_auth_options = VirtualAuthenticatorOptions()
+        virtual_auth_options.protocol = Protocol.CTAP2
+        virtual_auth_options.transport = Transport.INTERNAL
+        virtual_auth_options.has_resident_key = True
+        virtual_auth_options.has_user_verification = True
+        virtual_auth_options.is_user_verified = True
+        driver.add_virtual_authenticator(virtual_auth_options)
 
         driver.execute_cdp_cmd(
             "Emulation.setDeviceMetricsOverride",

--- a/uv.lock
+++ b/uv.lock
@@ -370,7 +370,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/28/fa/b2ba8229b9381e8f6
 
 [[package]]
 name = "ms-rewards-farmer"
-version = "3.1.0"
+version = "3.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
- Register a virtual CTAP2 authenticator on browser init to silently satisfy WebAuthn/passkey requests, preventing native OS dialogs
- Update CHANGELOG.md, bump version to 3.2.0