### PR TITLE
feat: auto-claim bonus points banner on rewards page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-05-28
+
+### Added
+
+- **Auto-claim bonus points**: New `BonusPoints` class detects and claims the bonus points banner on the rewards dashboard after login. Verifies the claim succeeded by waiting for the success message ([#27](https://github.com/maephisto666/MS-Rewards-Farmer/pull/27)).
+
 ## [3.5.0] - 2026-05-25
 
 ### Added

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from enum import Enum, auto
 from logging import handlers
 
 from src import (
+    BonusPoints,
     Browser,
     Login,
     PunchCards,
@@ -154,6 +155,7 @@ def executeBot(currentAccount):
             logging.info(
                 f"[POINTS] You have {formatNumber(startingPoints)} points on your account"
             )
+            BonusPoints(desktopBrowser).claimBonusPoints()
             Activities(desktopBrowser).completeActivities()
             PunchCards(desktopBrowser).completePunchCards()
             # VersusGame(desktopBrowser).completeVersusGame()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ms-rewards-farmer"
-version = "3.5.0"
+version = "3.6.0"
 description = "A 'simple' python application that uses Selenium to help with your M$ Rewards"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,5 @@
 from .remainingSearches import RemainingSearches
+from .bonusPoints import BonusPoints
 from .browser import Browser
 from .login import Login
 from .punchCards import PunchCards

--- a/src/bonusPoints.py
+++ b/src/bonusPoints.py
@@ -1,0 +1,51 @@
+import logging
+
+from selenium.common import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
+
+from src.browser import Browser
+
+
+class BonusPoints:
+    """
+    Class to handle bonus points claiming in MS Rewards.
+    """
+
+    def __init__(self, browser: Browser):
+        self.browser = browser
+        self.webdriver = browser.webdriver
+
+    def claimBonusPoints(self) -> None:
+        logging.info("[BONUS POINTS] Checking for bonus points to claim...")
+        try:
+            container = self.webdriver.find_elements(By.ID, "user-pointclaim-container")
+            if not container:
+                logging.info("[BONUS POINTS] No bonus points banner found")
+                return
+
+            claim_button = container[0].find_elements(
+                By.XPATH, ".//button[contains(@aria-label, 'Claim')]"
+            )
+            if not claim_button:
+                logging.info("[BONUS POINTS] Banner present but no Claim button (already claimed?)")
+                return
+
+            logging.info("[BONUS POINTS] Bonus points available, clicking Claim...")
+            claim_button[0].click()
+
+            WebDriverWait(self.webdriver, 10).until(
+                EC.text_to_be_present_in_element(
+                    (By.CSS_SELECTOR, "#user-pointclaim .title"), "claimed"
+                )
+            )
+            title = self.webdriver.find_element(
+                By.CSS_SELECTOR, "#user-pointclaim .title"
+            ).text
+            logging.info(f"[BONUS POINTS] {title}")
+
+        except TimeoutException:
+            logging.warning("[BONUS POINTS] Clicked Claim but could not verify success")
+        except Exception:
+            logging.error("[BONUS POINTS] Error claiming bonus points", exc_info=True)


### PR DESCRIPTION
### Changes

Adds a new `BonusPoints` class (following the same pattern as `Activities`, `PunchCards`, `Searches`) that handles the bonus points claim banner on the rewards dashboard.

**Flow:**
1. After login and recording starting points, check for the `#user-pointclaim-container` banner
2. If a "Claim" button is present, click it
3. Wait for the success message ("X bonus points claimed") to confirm
4. Log the result

The close button step is skipped (banner disappears on next page load anyway).

**Version bump:** 3.5.0 → 3.6.0

After merging, tag `3.6.0` should be pushed.