### PR TITLE
ci: bump release-please-action v4 -> v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps the release-please GitHub Action from `@v4` to `@v5`.

## Why
The first run of the workflow logged a `Node.js 20 is deprecated` warning. [v5.0.0](https://github.com/googleapis/release-please-action/releases/tag/v5.0.0) addresses it.

## What v5.0.0 changes
- **BREAKING (runtime only):** action upgraded to **Node 24** — resolves the deprecation warning. Not a config/behaviour change.
- Bumps the underlying release-please engine **17.3.0 → 17.6.0**.

## Risk
Minimal. Config files are untouched. Runners are GitHub-hosted `ubuntu-24.04`, which already ships Node 24 (no self-hosted runners in play).

🤖 Generated with [Claude Code](https://claude.com/claude-code)