### PR TITLE
chore: fix release-please squash-merge tagging and uv.lock drift

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
   "draft": false,
   "prerelease": false,
   "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore: release ${version}",
   "changelog-type": "default",
   "changelog-sections": [
     { "type": "feat",     "section": "Added" },
@@ -25,14 +26,7 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "package-name": "ms-rewards-farmer",
-      "extra-files": [
-        {
-          "type": "toml",
-          "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name == 'ms-rewards-farmer')].version"
-        }
-      ]
+      "package-name": "ms-rewards-farmer"
     }
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -386,7 +386,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/28/fa/b2ba8229b9381e8f6
 
 [[package]]
 name = "ms-rewards-farmer"
-version = "3.6.0"
+version = "3.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
Follow-up to the 3.7.0 release, which got stuck: the release PR merged and bumped the manifest, but the post-merge run could not create the tag/Release and aborted with *"untagged, merged release PRs outstanding"*. (3.7.0 has since been tagged + released manually to recover.)

## Root cause
release-please recovers the version-to-tag from the merged release PR's title/commit. The release PR title was `chore: release main` — **no version** — and squash-merge turned that into the commit subject, so release-please couldn't extract `3.7.0` and aborted.

## Changes
- **Add `pull-request-title-pattern: "chore: release ${version}"`** — future release PR titles (e.g. `chore: release 3.8.0`) carry the version, so it survives squash-merge and release-please tags automatically. This is the recurrence fix.
- **Sync `uv.lock` self-version `3.6.0` → `3.7.0`** — it had drifted from `pyproject.toml`.
- **Remove the `uv.lock` `extra-files` entry** — its JSONPath-filter TOML updater never actually worked (uv.lock was never bumped in any release PR), so it gave false confidence. See note below on automating this properly if desired.

## Note
With the `extra-files` entry gone, release-please no longer touches `uv.lock`. The self-version there is cosmetic (a `virtual = "."` entry, not used for resolution) and is kept correct by `uv lock`. True auto-bump would need a small workflow step running `uv lock` on the release PR — can add later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)