### PR TITLE
ci: bump dependency-review actions and align trigger syntax

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,9 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
-on: [pull_request]
+
+on:
+  pull_request:
 
 permissions:
   contents: read
@@ -15,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@v5


### PR DESCRIPTION
Updates the Dependency Review workflow.

## Changes
- `actions/checkout` `@v3` → `@v7` (latest)
- `actions/dependency-review-action` `@v3` → `@v5` (latest; v5 ships the newer Node runtime, avoiding the deprecated-Node warnings)
- `on: [pull_request]` → block style `on:` / `pull_request:`, matching the style used in `release-please.yml`. The old flow-sequence form was valid YAML, this is purely a consistency/readability change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)