### PR TITLE
test: assert English fallback for unknown localized-activities language

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -49,5 +49,9 @@ class TestUtils(TestCase):
     def test_load_localized_activities_with_invalid_language(self):
         from src.utils import load_localized_activities
 
-        with self.assertRaises(FileNotFoundError):
-            load_localized_activities("foo")
+        # An unknown language falls back to English rather than raising, so no
+        # account is skipped just because its locale has no query file.
+        fallback = load_localized_activities("foo")
+        english = load_localized_activities("en")
+        self.assertEqual(fallback.title_to_query, english.title_to_query)
+        self.assertEqual(fallback.ignore, english.ignore)


### PR DESCRIPTION
## What

`test_load_localized_activities_with_invalid_language` expected `load_localized_activities("foo")` to raise `FileNotFoundError`, but the loader was changed (in `c9f227f`) to **fall back to English** — it logs a warning and returns the `localized_activities.en` module instead of raising. The test was never updated, so the suite failed 12/13.

## Change

Update the test to assert the fallback behaviour: an unknown language returns the same `title_to_query` / `ignore` as `"en"`. Production code is unchanged — the graceful fallback is the intended behaviour (no account is skipped just because its locale has no query file).

## Verification

`uv run python -m unittest` → **13/13 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)