### PR TITLE
refactor: remove obsolete Bing info preference

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,21 +32,23 @@ an anti-detection Firefox-based browser, as an alternative to undetected-chromed
 bot detection. Revisiting this as a fresh feature once the codebase is stable would be
 worthwhile.
 
-### Revisit PREFER_BING_INFO and Data Sources
+### Revisit Bing information and dashboard data sources
 
-The codebase has two data sources for account info (points, remaining searches, user level):
+The current code uses two complementary data sources:
 
 - **Bing API** (`getBingInfo()`) -- HTTP call to `bing.com/rewards/panelflyout/getuserinfo`.
-  Faster (no page navigation), but undocumented and its schema has broken (e.g. `PCSearch`
-  key no longer exists). Currently disabled via `PREFER_BING_INFO = False`.
-- **RSC wire format** (`getDashboardData()`) -- Navigates to `rewards.microsoft.com` and
-  parses the Next.js RSC payload embedded in the page HTML (`src/rsc.py`). Reliable, but
-  requires a full page load.
+  It remains necessary to verify Bing Rewards authentication, retrieve search counters and
+  level when available, and report redemption-goal details. It is undocumented and its schema
+  can be unavailable or change by region, so search counting has conservative fallbacks.
+- **RSC wire format** (`getDashboardData()`) -- Navigates to `rewards.bing.com/dashboard` and
+  parses the Next.js RSC payload embedded in the page HTML (`src/rsc.py`). It is the
+  authoritative source for balance, daily-set items, activity cards, activity counters, and
+  streak-claim state.
 
-The `PREFER_BING_INFO` flag and all its `if/else` branches throughout `browser.py` and
-`utils.py` are a leftover from the upstream repo where it was always `True` and never
-exposed as a configuration option. Now that it's `False`, the Bing API code paths are dead
-code and should be removed.
+`PREFER_BING_INFO` was an obsolete upstream switch between the legacy `window.dashboard`
+scraper and the Bing API. The v4 RSC migration removed that dual path, and the unused switch
+was removed. Do not remove `getBingInfo()` or its callers until replacements exist for its
+remaining responsibilities.
 
 ### Developer Tooling and SDLC Cleanup
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,8 @@ worthwhile.
 
 The current code uses two complementary data sources:
 
-- **Bing API** (`getBingInfo()`) -- HTTP call to `bing.com/rewards/panelflyout/getuserinfo`.
+- **Bing API** (`getBingRewardsInfo()`) -- HTTP call to
+  `bing.com/rewards/panelflyout/getuserinfo`.
   It remains necessary to verify Bing Rewards authentication, retrieve search counters and
   level when available, and report redemption-goal details. It is undocumented and its schema
   can be unavailable or change by region, so search counting has conservative fallbacks.
@@ -47,7 +48,7 @@ The current code uses two complementary data sources:
 
 `PREFER_BING_INFO` was an obsolete upstream switch between the legacy `window.dashboard`
 scraper and the Bing API. The v4 RSC migration removed that dual path, and the unused switch
-was removed. Do not remove `getBingInfo()` or its callers until replacements exist for its
+was removed. Do not remove `getBingRewardsInfo()` or its callers until replacements exist for its
 remaining responsibilities.
 
 ### Developer Tooling and SDLC Cleanup

--- a/docs/v4-plan.md
+++ b/docs/v4-plan.md
@@ -27,8 +27,8 @@ The following planned work remains open:
 - Search counters are still read from the legacy Bing information endpoint when available,
   with conservative fallback limits when they are not. A native replacement has not been
   found in the RSC payload.
-- `PREFER_BING_INFO` remains declared in `src/utils.py`, although the old dashboard
-  dual-path is no longer used.
+- The obsolete `PREFER_BING_INFO` preference and its legacy dashboard dual-path were removed;
+  active Bing information calls remain for search authentication, search counters, and goals.
 - Phase 4 cleanup is deferred: `selenium-wire`, `pyautogui`, `setuptools<81`, and
   undetected-chromedriver remain dependencies; Ruff, pre-commit, and dedicated lint/test CI
   have not been added.

--- a/src/browser.py
+++ b/src/browser.py
@@ -19,7 +19,7 @@ from src.utils import (
     getBrowserConfig,
     getProjectRoot,
     saveBrowserConfig,
-    PREFER_BING_INFO, LANGUAGE, COUNTRY,
+    LANGUAGE, COUNTRY,
 )
 
 

--- a/src/browser.py
+++ b/src/browser.py
@@ -292,7 +292,7 @@ class Browser:
         self, desktopAndMobile: bool = False
     ) -> RemainingSearches | int:
         try:
-            bingInfo = self.utils.getBingInfo()
+            bingInfo = self.utils.getBingRewardsInfo()
             counters = bingInfo["flyoutResult"]["userStatus"]["counters"]
             pcSearch: dict = counters["PCSearch"][0]
             pointProgressMax: int = pcSearch["pointProgressMax"]
@@ -323,7 +323,7 @@ class Browser:
             return remainingMobileSearches if self.mobile else remainingDesktopSearches
 
         except (KeyError, TypeError, AssertionError) as exc:
-            # getBingInfo did not return Bing Rewards counters — common for Microsoft
+            # getBingRewardsInfo did not return Bing Rewards counters — common for Microsoft
             # Rewards accounts in regions where Bing Rewards is a separate programme
             # (e.g. NL). Fall back to a conservative ceiling; bingSearch() exits
             # naturally when searches stop earning points.

--- a/src/utils.py
+++ b/src/utils.py
@@ -40,8 +40,6 @@ from urllib3 import Retry
 
 from .constants import REWARDS_DASHBOARD_URL, REWARDS_EARN_URL, SEARCH_URL
 
-PREFER_BING_INFO = True
-
 
 class Config(dict):
     """

--- a/src/utils.py
+++ b/src/utils.py
@@ -352,7 +352,7 @@ class Utils:
 
     def _isBingRewardsAuthenticated(self) -> bool:
         try:
-            return bool(self.getBingInfo().get("isRewardsUser"))
+            return bool(self.getBingRewardsInfo().get("isRewardsUser"))
         except Exception:
             return False
 
@@ -412,7 +412,7 @@ class Utils:
         """
         return self.getDashboardData().todays_daily_set()
 
-    def getBingInfo(self) -> Any:
+    def getBingRewardsInfo(self) -> Any:
         session = makeRequestsSession()
         retries = CONFIG.retries.max
         backoff_factor = CONFIG.get("retries.backoff-factor")
@@ -430,7 +430,7 @@ class Utils:
                 )  # pylint: disable=no-member
                 data = response.json()
                 logging.debug(
-                    "getBingInfo: isRewardsUser=%s userInfo.balance=%s flyoutResult.userStatus.availablePoints=%s",
+                    "getBingRewardsInfo: isRewardsUser=%s userInfo.balance=%s flyoutResult.userStatus.availablePoints=%s",
                     data.get("isRewardsUser"),
                     data.get("userInfo", {}).get("balance"),
                     data.get("flyoutResult", {}).get("userStatus", {}).get("availablePoints"),
@@ -449,7 +449,7 @@ class Utils:
 
     def isLoggedIn(self) -> bool:
         try:
-            if self.getBingInfo()["isRewardsUser"]:
+            if self.getBingRewardsInfo()["isRewardsUser"]:
                 return True
         except Exception:
             pass
@@ -462,19 +462,19 @@ class Utils:
         return "/dashboard" in self.webdriver.current_url
 
     def getAccountPoints(self) -> int:
-        # RSC balance is always accurate; getBingInfo may return 0 in some regions.
+        # RSC balance is always accurate; getBingRewardsInfo may return 0 in some regions.
         # getDashboardData() navigates to /dashboard and parses the RSC payload.
         return self.getDashboardData().balance
 
     def getGoalPoints(self) -> int:
         try:
-            return self.getBingInfo()["flyoutResult"]["userGoal"]["price"]
+            return self.getBingRewardsInfo()["flyoutResult"]["userGoal"]["price"]
         except (KeyError, TypeError):
             return 0
 
     def getGoalTitle(self) -> str:
         try:
-            return self.getBingInfo()["flyoutResult"]["userGoal"]["title"]
+            return self.getBingRewardsInfo()["flyoutResult"]["userGoal"]["title"]
         except (KeyError, TypeError):
             return ""
 


### PR DESCRIPTION
## Summary
- remove the unused `PREFER_BING_INFO` preference and import
- rename the active Bing Rewards panel API accessor to `getBingRewardsInfo()`
- clarify the distinct responsibilities of Bing information and dashboard RSC data in project documentation

## Testing
- `uv run python -m unittest`
- `git diff --check`