### PR TITLE
fix(ci): configure release group title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
   "draft": false,
   "prerelease": false,
   "separate-pull-requests": false,
-  "pull-request-title-pattern": "chore: release ${version}",
+  "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "changelog-type": "default",
   "changelog-sections": [
     { "type": "feat",     "section": "Added" },


### PR DESCRIPTION
## Summary
- configure the manifest group release title pattern with component and version fields
- remove the unused per-package release title pattern
- allow Release Please to recognize merged group release PRs and create tags/releases

## Validation
- python3 -m json.tool release-please-config.json
- git diff --check