### PR TITLE
fix: decode Bing Rewards responses as UTF-8

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -428,6 +428,9 @@ class Utils:
                 assert (
                     response.status_code == requests.codes.ok
                 )  # pylint: disable=no-member
+                # Bing sometimes sends UTF-8 JSON without a usable charset header.
+                # Decode it explicitly so localized goal titles are not mojibake.
+                response.encoding = "utf-8"
                 data = response.json()
                 logging.debug(
                     "getBingRewardsInfo: isRewardsUser=%s userInfo.balance=%s flyoutResult.userStatus.availablePoints=%s",

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,12 +1,37 @@
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 # noinspection PyPackageRequirements
 from parameterized import parameterized
+from requests import Response
 
-from src.utils import CONFIG, APPRISE, isValidCountryCode, isValidLanguageCode
+from src.utils import (
+    CONFIG,
+    APPRISE,
+    Utils,
+    isValidCountryCode,
+    isValidLanguageCode,
+)
 
 
 class TestUtils(TestCase):
+    def test_bing_rewards_info_decodes_goal_title_as_utf8(self):
+        response = Response()
+        response.status_code = 200
+        response.encoding = "ISO-8859-1"
+        response._content = (
+            b'{"flyoutResult":{"userGoal":{"title":"M\xc3\xbcnchen"}}}'
+        )
+        session = MagicMock()
+        session.get.return_value = response
+        webdriver = MagicMock()
+        webdriver.get_cookies.return_value = []
+
+        with patch("src.utils.makeRequestsSession", return_value=session):
+            info = Utils(webdriver).getBingRewardsInfo()
+
+        self.assertEqual(info["flyoutResult"]["userGoal"]["title"], "München")
+
     def test_send_notification(self):
         CONFIG.apprise.enabled = True
         APPRISE.notify("body", "title")


### PR DESCRIPTION
## Summary
- decode the Bing Rewards panel response as UTF-8 before JSON parsing
- preserve localized user-goal titles when the endpoint reports an incorrect charset
- add a regression test for a German title

Fixes #38

## Validation
- .venv/bin/python -m unittest
- .venv/bin/python -m py_compile src/utils.py test/test_utils.py
- git diff --check