### PR TITLE
fix(ci): separate release pull requests

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
   "prerelease": false,
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
   "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "changelog-type": "default",
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- enable separate Release Please pull requests
- avoid the grouped manifest release PR parser that cannot associate the configured Python package component

## Validation
- python3 -m json.tool release-please-config.json
- git diff --check

After merge, Release Please should be rerun after clearing stale state from the failed 4.0.2 release PR. No release will be created manually.