### PR TITLE
fix(ci): remove release package name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,8 +25,7 @@
   ],
   "packages": {
     ".": {
-      "release-type": "python",
-      "package-name": "ms-rewards-farmer"
+      "release-type": "python"
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove the package-name override that conflicts with unprefixed release tags
- let the Python releaser read the project name from pyproject.toml while using an empty release component
- enable Release Please to recognize componentless historical release PRs and create releases automatically

## Validation
- python3 -m json.tool release-please-config.json
- git diff --check