### PR TITLE
fix(ci): remove release name prefix

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
   "include-v-in-tag": false,
+  "include-v-in-release-name": false,
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,


### PR DESCRIPTION
## Summary
- configure Release Please to create GitHub Release names without a v prefix
- retain the existing unprefixed tag format

## Validation
- python3 -m json.tool release-please-config.json
- git diff --check